### PR TITLE
docs: keep legacy game-api for older backend versions

### DIFF
--- a/kubernetes/argo/application-game-api.yaml
+++ b/kubernetes/argo/application-game-api.yaml
@@ -1,3 +1,7 @@
+# LEGACY: kept intentionally for older cosy-backend versions that still resolve game
+# artwork via the live SteamGridDB proxy (cosy-gameapi-service). New backend versions
+# source games from the template-service /v3/games endpoint and do NOT depend on this.
+# Do NOT remove while any deployed backend predates the v3 games migration.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## What
Phase 5 — deployment note only.

The new backend version sources games from the template-service **`/v3/games`** endpoint and no longer depends on the live SteamGridDB proxy. Older deployed backends still use the proxy, so the `cosy-gameapi` ArgoCD Application is **intentionally kept** and now documented as legacy.

No manifest behavior change: the backend deployment reads its template/games URLs from `application.yaml` defaults (already on v3) and already mounts `docker.sock` as root, so host mounts work without changes.

Refs Magenta-Mause/Cosy#70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
