### PR TITLE
Limit GITHUB_TOKEN permissions in deployment workflows

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-manifests.yml
+++ b/.github/workflows/update-manifests.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   update-manifests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Generate GitHub App Token
         id: app-token


### PR DESCRIPTION
Fixes both open [code scanning alerts](https://github.com/Magenta-Mause/Cosy-Internal-Deployment/security/code-scanning) (`actions/missing-workflow-permissions`, medium):

| Alert | File |
|---|---|
| [#2](https://github.com/Magenta-Mause/Cosy-Internal-Deployment/security/code-scanning/2) | `.github/workflows/deploy-vps.yml` |
| [#1](https://github.com/Magenta-Mause/Cosy-Internal-Deployment/security/code-scanning/1) | `.github/workflows/update-manifests.yml` |

## What changed

`permissions: { contents: read }` added at job level in both workflows. `issue-redirect.yml` already had an explicit block (`issues: write`) and was not flagged.

## Why `contents: read` is sufficient

- **deploy-vps** — the job only runs `actions/checkout`. The `scp-action` / `ssh-action` steps authenticate against the VPS with `secrets.VPS_SSH_KEY`, independent of `GITHUB_TOKEN`.
- **update-manifests** — both the checkout and the `git push` use the GitHub App installation token from `actions/create-github-app-token`, so `GITHUB_TOKEN` never needs write access to contents.

## Note on actual exposure

The repository's default workflow permission is already `read`, so the tokens were not effectively write-all. This change makes the restriction explicit at the workflow level, so it holds even if the repo/org default is widened later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)